### PR TITLE
available_data.FieldCount.to_dict()

### DIFF
--- a/piplapis/data/available_data.py
+++ b/piplapis/data/available_data.py
@@ -79,7 +79,7 @@ class FieldCount(Serializable):
     def to_dict(self):
         d = {}
         for child in self.children:
-            if getattr(self, child) > 0:
+            if getattr(self, child):
                 d[child] = getattr(self, child)
         return d
 


### PR DESCRIPTION
In Python3, can't compare None to 0. Instead just check for truthiness.
