### PR TITLE
Check isinstance of datetime first and then date

### DIFF
--- a/piplapis/data/fields.py
+++ b/piplapis/data/fields.py
@@ -136,10 +136,10 @@ class Field(Serializable):
                 value = getattr(self, attr)
                 if isinstance(value, Serializable):
                     value = value.to_dict()
-                if isinstance(value, datetime.date):
-                    value = date_to_str(value)
                 if isinstance(value, datetime.datetime):
                     value = datetime_to_str(value)
+                if isinstance(value, datetime.date):
+                    value = date_to_str(value)
                 if value or isinstance(value, (bool, int)):
                     d[prefix + attr] = value
         if hasattr(self, 'display') and self.display:


### PR DESCRIPTION
Since `datetime` is a child of `date`, checking `isinstance` of `date` will always be true on `datetime` instances.
So checking first for `datetime` will fix issues of `y.from_dict(x.to_dict())` producing `datetime.strptime(str)` exceptions.
