### PR TITLE
Fix - Use the correct urlencode depending on Python version

### DIFF
--- a/piplapis/search.py
+++ b/piplapis/search.py
@@ -283,7 +283,7 @@ class SearchAPIRequest(object):
     def url(self):
         """The URL of the request (str)."""
         query = self.get_search_query()
-        return self.get_base_url() + urllib.urlencode(query, doseq=True)
+        return self.get_base_url() + urlencode(query, doseq=True)
 
     def get_search_query(self):
         query = {"key": self.api_key}

--- a/piplapis/thumbnail.py
+++ b/piplapis/thumbnail.py
@@ -3,7 +3,10 @@ This module contains wrapper code to the DEPRECATED paid thumbnail API v2.
 Please use Image.get_thumbnail_url instead, as it uses the newer, complementary thumbnail service.
 """
 import logging
-import urllib
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
 
 from piplapis.data import Image
 from piplapis.data.utils import to_utf8
@@ -91,4 +94,4 @@ def generate_thumbnail_url(image_url, height, width, favicon_domain=None,
         'favicon_domain': to_utf8(favicon_domain or ''),
         'zoom_face': zoom_face,
     }
-    return BASE_URL + urllib.urlencode(query)
+    return BASE_URL + urlencode(query)


### PR DESCRIPTION
On some parts, we were using `urllib.urlencode`, while on others we were using a different `urlencode` depending if we're on Py3 or Py2. This PR consolidates to always use the urlencode available on Py2/Py3.

Without this PR, the following code fails on Python3:

```python
from piplapis.search import SearchAPIRequest

request = SearchAPIRequest(api_key='API_KEY', raw_name='Jane Doe')
request.url
# Throws on Py3 complaining that urllib.urlencode doesn't exist.
```